### PR TITLE
Fix test class naming issue, causing building tests to fail.

### DIFF
--- a/javafx-d3-demo/src/test/java/org/treez/javafxd3/d3/selection/SubselectionsTest.java
+++ b/javafx-d3-demo/src/test/java/org/treez/javafxd3/d3/selection/SubselectionsTest.java
@@ -10,7 +10,7 @@ import org.treez.javafxd3.d3.core.JsObject;
 /**
  * Testing the internal structure of the selections and sub selections.
  */
-public class SubSelectionsTest extends AbstractSelectionTest {
+public class SubselectionsTest extends AbstractSelectionTest {
 
 	@Override
 	public void doTest() {


### PR DESCRIPTION
`mvn clean install` was failing because `class SubSelectionsTest` was in `SubselectionsTest.java` file. As git won't generally track filename casing, I went with renaming the class instead of the file.